### PR TITLE
Really shut up emacs during saving

### DIFF
--- a/auto-save.el
+++ b/auto-save.el
@@ -142,10 +142,7 @@ avoid delete current indent space when you programming."
                  (or (not (boundp 'company-candidates))
                      (not company-candidates)))
             (push (buffer-name) autosave-buffer-list)
-            (if auto-save-silent
-                (with-temp-message
-                    (with-current-buffer " *Minibuf-0*" (buffer-string))
-                  (basic-save-buffer))
+            (let ((inhibit-message auto-save-silent))
               (basic-save-buffer))
             ))
         ;; Tell user when auto save files.


### PR DESCRIPTION
`inhibit-message` is built-in mechanism to prevent Emacs making noise in echo area. It's better than an ugly hack.