### PR TITLE
设定 auto-save-disbale-predicates 禁用 auto-save

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ In your `~/.emacs`, add the following three lines:
 ;;; disable auto save mode when current filetype is an gpg file.
 (setq auto-save-disable-predicates
       '((lambda ()
-	  (string-suffix-p
-	   "gpg"
-	   (file-name-extension (buffer-name)) t))))
+      (string-suffix-p
+      "gpg"
+      (file-name-extension (buffer-name)) t))))
 ```

--- a/README.md
+++ b/README.md
@@ -14,4 +14,12 @@ In your `~/.emacs`, add the following three lines:
 
 (setq auto-save-silent t)   ; quietly save
 (setq auto-save-delete-trailing-whitespace t)  ; automatically delete spaces at the end of the line when saving
+
+;;; custom predicates if you don't want auto save.
+;;; disable auto save mode when current filetype is an gpg file.
+(setq auto-save-disable-predicates
+      '((lambda ()
+	  (string-suffix-p
+	   "gpg"
+	   (file-name-extension (buffer-name)) t))))
 ```

--- a/auto-save.el
+++ b/auto-save.el
@@ -139,10 +139,10 @@ avoid delete current indent space when you programming."
                  ;; Company is not active?
                  (or (not (boundp 'company-candidates))
                      (not company-candidates))
-		 ;; tell auto-save don't save
-		 (not (seq-some (lambda (predicate)
-				     (funcall predicate))
-				   auto-save-disable-predicates)))
+                 ;; tell auto-save don't save
+                 (not (seq-some (lambda (predicate)
+                                  (funcall predicate))
+                                auto-save-disable-predicates)))
             (push (buffer-name) autosave-buffer-list)
             (if auto-save-silent
                 ;; `inhibit-message' can shut up Emacs, but we want

--- a/auto-save.el
+++ b/auto-save.el
@@ -115,6 +115,9 @@ avoid delete current indent space when you programming."
   :type 'boolean
   :group 'auto-save)
 
+(defvar auto-save-disable-predicates
+  nil "disable auto save in these case.")
+
 ;; Emacs' default auto-save is stupid to generate #foo# files!
 (setq auto-save-default nil)
 
@@ -135,7 +138,11 @@ avoid delete current indent space when you programming."
                      (not yas--active-snippets))
                  ;; Company is not active?
                  (or (not (boundp 'company-candidates))
-                     (not company-candidates)))
+                     (not company-candidates))
+		 ;; tell auto-save don't save
+		 (not (seq-some (lambda (predicate)
+				     (funcall predicate))
+				   auto-save-disable-predicates)))
             (push (buffer-name) autosave-buffer-list)
             (if auto-save-silent
                 ;; `inhibit-message' can shut up Emacs, but we want


### PR DESCRIPTION
我编辑 .authinfo.gpg 的时候，auto-save 自动保存, 一保存就要输入密码，密码还没又输完，
又保存了，然后又要输入密码 .........

我添加了这个小功能，可以自定义一串谓词，
如果符合谓词条件，那么auto-save 终止保存行为。
设置方式如下
···
(setq auto-save-disable-predicates
        '((lambda ()
            (string-suffix-p "gpg" buffer-name) t))))
···