### PR TITLE
Use cursor point as line end position

### DIFF
--- a/auto-save.el
+++ b/auto-save.el
@@ -169,7 +169,7 @@ avoid delete current indent space when you programming."
   (interactive)
   (when auto-save-delete-trailing-whitespace
     (let ((begin (line-beginning-position))
-          (end (line-end-position)))
+          (end (point)))
       (save-excursion
         (when (< (point-min) begin)
           (save-restriction
@@ -177,7 +177,7 @@ avoid delete current indent space when you programming."
             (delete-trailing-whitespace)))
         (when (> (point-max) end)
           (save-restriction
-            (narrow-to-region (1+ end) (point-max))
+            (narrow-to-region end (point-max))
             (delete-trailing-whitespace)))))))
 
 (defvar auto-save-timer nil)


### PR DESCRIPTION
问题: 当光标所在的行后面刚好具有白空格的情况下, 在保存后, 并没有将这一行后面的白空格去掉