### PR TITLE
fix point move issue

### DIFF
--- a/auto-save.el
+++ b/auto-save.el
@@ -126,7 +126,7 @@ avoid delete current indent space when you programming."
   (interactive)
   (let ((autosave-buffer-list))
     (ignore-errors
-      (save-excursion
+      (with-current-buffer (current-buffer)
         (dolist (buf (buffer-list))
           (set-buffer buf)
           (when (and

--- a/auto-save.el
+++ b/auto-save.el
@@ -126,7 +126,7 @@ avoid delete current indent space when you programming."
   (interactive)
   (let ((autosave-buffer-list))
     (ignore-errors
-      (with-current-buffer (current-buffer)
+      (save-current-buffer
         (dolist (buf (buffer-list))
           (set-buffer buf)
           (when (and


### PR DESCRIPTION
fix #13 avoid `save-excursion` when `current-buffer` is in the `(buffer-list)`

I have tested it on my side, the problem is is partially solved
1. the cursor will not move the the beginning of buffer
2. there still problem, `auto-save` will trigger `blacken-buffer` **while I am coding** and it will format the code, and result in the cursor location change, not to beginning of the buffer, which is good, but it changed the location a little, to the next line for example, if blacken format the code to two lines, which is still very noisy. Maybe there is better alternatives to solve this issue?

