### PR TITLE
Don't save the buffer associated with org-capture

### DIFF
--- a/auto-save.el
+++ b/auto-save.el
@@ -144,6 +144,9 @@ avoid delete current indent space when you programming."
                  ;; Corfu is not active?
                  (or (not (boundp 'corfu--total))
                      (zerop corfu--total))
+                 ;; Org-capture is not active?
+                 (not (eq (buffer-base-buffer (get-buffer (concat "CAPTURE-" (buffer-name))))
+                          buf))
                  ;; tell auto-save don't save
                  (not (seq-some (lambda (predicate)
                                   (funcall predicate))


### PR DESCRIPTION
@manateelazycat 

Support `org-capture `by default, should fix the issue https://github.com/manateelazycat/auto-save/issues/17